### PR TITLE
Correção excluir edital

### DIFF
--- a/app/Http/Controllers/EventoController.php
+++ b/app/Http/Controllers/EventoController.php
@@ -449,6 +449,7 @@ class EventoController extends Controller
         }
         if(isset($trabalhos)){
           $trabalhos->delete();
+          Trabalho::withTrashed()->where('evento_id', $id)->update(['evento_id' => null]);
         }
 
         Storage::deleteDirectory('pdfEdital/' . $evento->id );


### PR DESCRIPTION
Estava ocorrendo um erro de referencia, por que o delete de trabalhos é soft, então a referencia ao edital continuava na tabela. Atualizei as rows que continham a referencia para null. @carlos1270 